### PR TITLE
allow bare URL to bring up the html page

### DIFF
--- a/shortener/app.py
+++ b/shortener/app.py
@@ -40,6 +40,7 @@ def _shortng():
     return shortng()
 
 
+@app.route('/')
 @app.route('/shortener.html')
 def _shortener():
     from shortener.shortng import shortener


### PR DESCRIPTION
Added '/' route that goes to same handler as "shortener.html".

Tested locally, pushed to cloud and tested in `shortng-test` at https://shortng-test-833853795110.us-east4.run.app.

The container I pushed is `dc5039`, which could just be deployed to production if desired.

Fixes #8 .